### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Hacker News MCP Server
 
+[![smithery badge](https://smithery.ai/badge/mcp-hn)](https://smithery.ai/server/mcp-hn)
+
 A Model Context Protocol (MCP) server that provides tools for fetching information from Hacker News.
 
 ## Tools
@@ -35,6 +37,14 @@ User: Can you use the puppeteer tool to read the article about <AI> and also use
 
 ## Quickstart
 
+### Installing via Smithery
+
+To install Hacker News MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp-hn):
+
+```bash
+npx -y @smithery/cli install mcp-hn --client claude
+```
+
 ### Claude Desktop:
 
 Update the following:
@@ -55,10 +65,5 @@ With the following for production:
   }
 }
 ```
-
-
-
-
-
 
 


### PR DESCRIPTION
This PR makes the following changes to the README:

1. Adds installation instructions to automatically install the Hacker News MCP Server for Claude Desktop using Smithery CLI. This facilitates an easier setup process for users.
2. Includes a badge to display the number of installations from Smithery: [![smithery badge](https://smithery.ai/badge/mcp-hn)](https://smithery.ai/server/mcp-hn).

Feel free to suggest any modifications!