### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Model Context Protocol (MCP) server that provides tools for fetching information from Hacker News.
 
+<a href="https://glama.ai/mcp/servers/e0rco8dfgt"><img width="380" height="200" src="https://glama.ai/mcp/servers/e0rco8dfgt/badge" alt="mcp-hn MCP server" /></a>
+
 ## Tools
 
 - `get_stories` Fetching (top, new, ask_hn, show_hn) stories


### PR DESCRIPTION
This PR adds a badge for the [mcp-hn](https://glama.ai/mcp/servers/e0rco8dfgt) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/e0rco8dfgt"><img width="380" height="200" src="https://glama.ai/mcp/servers/e0rco8dfgt/badge" alt="mcp-hn MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.