### PR TITLE
Add GitHub Actions workflow for Python package with Conda

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,0 +1,34 @@
+name: Python Package using Conda
+
+on: [push]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 5
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Add conda to system path
+      run: |
+        # $CONDA is an environment variable pointing to the root of the miniconda directory
+        echo $CONDA/bin >> $GITHUB_PATH
+    - name: Install dependencies
+      run: |
+        conda env update --file environment.yml --name base
+    - name: Lint with flake8
+      run: |
+        conda install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        conda install pytest
+        pytest


### PR DESCRIPTION
- name: Setup Java JDK uses: actions/setup-java@v5.5.0 with: # The Java version to set up. Takes a whole or semver Java version. See examples of supported syntax in README file java-version: # optional # The path to a file containing the Java version to set up (.java-version, .tool-versions, .sdkmanrc). Used when java-version is not set. See examples of supported syntax in README file java-version-file: # optional # Java distribution. See the list of supported distributions in README file. This input is required except when java-version-file points to .sdkmanrc with a recognized distribution suffix (e.g., java=21.0.5-tem). distribution: # optional # The package type (jdk, jre, jdk+fx, jre+fx) java-package: # optional, default is jdk # The architecture of the package (defaults to the action runner's architecture) architecture: # optional # Path to where the compressed JDK is located jdkFile: # optional # Set this option if you want the action to check for the latest available version that satisfies the version spec check-latest: # optional # Set this option to false if you want to install a JDK but not make it the default. When false, JAVA_HOME and PATH are not updated, but JAVA_HOME_<major>_<arch> is still set. set-default: # optional, default is true # Verify downloaded Java package signatures when supported by the selected distribution verify-signature: # optional # ASCII-armored GPG public key used to verify the downloaded package signature. Overrides the default bundled key for the selected distribution. verify-signature-public-key: # optional # ID of the distributionManagement repository in the pom.xml file. Default is `github` server-id: # optional, default is github # Environment variable name for the username for authentication to the Apache Maven repository. Default is $GITHUB_ACTOR server-username: # optional, default is GITHUB_ACTOR # Environment variable name for password or token for authentication to the Apache Maven repository. Default is $GITHUB_TOKEN server-password: # optional, default is GITHUB_TOKEN # Path to where the settings.xml file will be written. Default is ~/.m2. settings-path: # optional # Overwrite the settings.xml file if it exists. Default is "true". overwrite-settings: # optional, default is true # GPG private key to import. Default is empty string. gpg-private-key: # optional, default is  # Environment variable name for the GPG private key passphrase. Defaults to GPG_PASSPHRASE when gpg-private-key is set; ignored otherwise. gpg-passphrase: # optional # Name of the build platform to cache dependencies. It can be "maven", "gradle" or "sbt". cache: # optional # The path to a dependency file: pom.xml, build.gradle, build.sbt, etc. This option can be used with the `cache` option. If this option is omitted, the action searches for the dependency file in the entire repository. This option supports wildcards and a list of file names for caching multiple dependencies. cache-dependency-path: # optional # Workaround to pass job status to post job step. This variable is not intended for manual setting job-status: # optional, default is ${{ job.status }} # The token used to authenticate when fetching version manifests hosted on github.com, such as for the Microsoft Build of OpenJDK. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting. token: # optional, default is ${{ github.server_url == 'https://github.com' && github.token || '' }} # Name of Maven Toolchain ID if the default name of "${distribution}_${java-version}" is not wanted. See examples of supported syntax in Advanced Usage file mvn-toolchain-id: # optional # Name of Maven Toolchain Vendor if the default name of "${distribution}" is not wanted. See examples of supported syntax in Advanced Usage file mvn-toolchain-vendor: # optional # Whether Maven should print artifact download/transfer progress to the build log. When "false" (default) the action sets "-ntp" (--no-transfer-progress) in MAVEN_ARGS to produce cleaner logs. Set to "true" to keep the progress output. Has no effect on non-Maven builds. show-download-progress: # optional